### PR TITLE
CMake: guard the standalone `eirene` target in coupled builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -610,10 +610,12 @@ else()
                       ARCHIVE_OUTPUT_DIRECTORY
                       ${PROJECT_BINARY_DIR}/../lib${CMAKE_BUILD_TYPE}
                       OUTPUT_NAME ${EIRENE_LIBRARY_NAME}${EIRENE_POSTFIX})
+  if ( NOT B25_EIRENE )
   set_target_properties(eirene PROPERTIES
                       RUNTIME_OUTPUT_DIRECTORY
                       ${PROJECT_BINARY_DIR}/../bin${CMAKE_BUILD_TYPE}
                       OUTPUT_NAME ${EIRENE_EXECUTABLE_NAME}${EIRENE_POSTFIX})
+  endif()
 endif()
 
 # Adds optional local dependencies


### PR DESCRIPTION
## Summary

In `src/CMakeLists.txt`, the block that sets the output directory/name has two
branches: `if(DEFINED ENV{SOLPS_CPP})` (coupled SOLPS-ITER build) and its
`else()` (standalone Eirene, using per-config `lib${CMAKE_BUILD_TYPE}` /
`bin${CMAKE_BUILD_TYPE}` dirs). The first branch already guards the `eirene`
executable target with `if(NOT B25_EIRENE)`, but the `else()` branch sets
properties on `eirene` unconditionally. The `eirene` executable target is only
created when `NOT B25_EIRENE`, so a coupled configure (`-DB25_EIRENE=ON`) that
reaches the `else()` branch fails with:

```
CMake Error at CMakeLists.txt:613 (set_target_properties):
  set_target_properties Can not find target to add properties to: eirene
```

## Fix

Wrap the `eirene` property block in the `else()` branch in `if(NOT B25_EIRENE)`,
mirroring the `if(DEFINED ENV{SOLPS_CPP})` branch.

## Notes

- One-line guard; no change for standalone builds, nor for coupled builds that
  take the `SOLPS_CPP` branch.
- Verified: a coupled `-DB25_EIRENE=ON -DCMAKE_BUILD_TYPE=Debug` configure that
  previously errored at `set_target_properties(eirene ...)` now configures
  cleanly.
- Surfaced during the foss/intel 2025b toolchain work (CMake 4.0.3); hardens the
  coupled (notably debug) configure path.
