### PR TITLE
Added deallocate statement or Rtab and Etab

### DIFF
--- a/src/file-handling/wrplam_shrt.F
+++ b/src/file-handling/wrplam_shrt.F
@@ -474,7 +474,11 @@ c         irel=nfla_ir(irea)
 cdr  case 6,7: to be done
         end select
       ENDDO
-
+c
+      IF (ALLOCATED(RTAB)) THEN
+        DEALLOCATE (RTAB)
+        DEALLOCATE (ETAB)
+      END IF
       CLOSE (UNIT=13+ifoff)
       RETURN
 


### PR DESCRIPTION
RTAB and ETAB were not properly deallocated, causing runtime errors when using EDGE2D.
Bug fix: add deallocate statements.

Only affected simulations with neutral-neutral collisions.