### PR TITLE
Fix build for GNU Make ≥ 4.4

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -578,7 +578,7 @@ ifneq (${MOD},o)
 	@echo '# 5b' >> ${OBJDIR}/dependencies
 endif
 
-listobj: DIMENSIONS ${SRCDIR}/assistant/version.f local
+listobj: DIMENSIONS ${SRCDIR}/assistant/version.f local | $(OBJDIR)
 	@rm -f ${OBJDIR}/LISTOBJ ; touch ${OBJDIR}/LISTOBJ ; l="OBJS =" ; \
 	for d in `echo "$(FPATH)" | tr : \ `; do \
 		l="$$l `(cd $$d > /dev/null; echo *.f)`"; \
@@ -693,7 +693,7 @@ ${SRCEIR}/Database/METHANE:
 ${SRCEIR}/Database/METHAN: ${SRCEIR}/Database/METHANE
 	-ln -s ${SRCEIR}/Database/METHANE ${SRCEIR}/Database/METHAN
 
-${OBJDIR}/mpiversion.mk: ${MAKES}
+${OBJDIR}/mpiversion.mk: ${MAKES} | $(OBJDIR)
 ifdef NO_MPI
 	echo 'MPI_VERSION=0' > ${OBJDIR}/mpiversion.mk
 else

--- a/config/config.DARWIN.gfortran
+++ b/config/config.DARWIN.gfortran
@@ -26,7 +26,7 @@ endif
 endif
 
 #LDLIBS   = -L/usr/local/lib -L/usr/X11R6/lib
-LDLIBS    = -L/usr/local/lib -L$(XQUARTZ_HOME)/lib
+LDLIBS    = -L$(shell brew --prefix)/lib -L$(XQUARTZ_HOME)/lib
 
 INCMOD    = -B
 


### PR DESCRIPTION
**Symptom**

    touch: .../builds/<toolchain>/LISTOBJ: No such file or directory
    *** [listobj] Error 1

**Cause**
Each module `include`s generated files (`LISTOBJ`, `dependencies`) whose build directory `$(OBJDIR)` is created by a *different* rule (`mkdir -p $(OBJDIR)`) than the one that first writes into it. This relied on GNU Make rebuilding included makefiles in the *inverse* of their source order. GNU Make 4.4 (31 Oct 2022) reversed this — per its NEWS:

> the order in which makefiles are rebuilt is the same order in which make
> processed them (previously it was, roughly, the inverse).

So on ≥ 4.4 the `LISTOBJ` rule runs before the `mkdir` and `touch` fails. Builds succeed on ≤ 4.3, fail on ≥ 4.4. Explicitly tested.

**Fix**
Make the directory an order-only prerequisite of the writing targets:

    listobj: ... | $(OBJDIR)